### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,6 +3,9 @@
 
 name: Python package
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/mano8/imgtools_m8/security/code-scanning/1](https://github.com/mano8/imgtools_m8/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily reads repository contents and uploads coverage reports, the permissions can be limited to `contents: read`. If additional permissions are required for specific steps, they can be added explicitly.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. Alternatively, it can be added to individual jobs if different jobs require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
