### PR TITLE
feat: in-memory process_image bytes API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `process_image(bytes) -> list[VariantResult]` storage-agnostic in-memory API
 - `imgtools download-models` CLI; DNN models fetched on demand and SHA256-verified
 - `IMGTOOLS_M8_MODELS_DIR` env override for model location
 - `ModelNotFoundError` raised with a download hint when a required model is absent

--- a/README.md
+++ b/README.md
@@ -268,6 +268,29 @@ switches from single-process (`ImageProcessing`) to multiprocess
 (`MultiProcessImage`); the worker count is clamped to `cpu_count - 1`
 to avoid saturating the system.
 
+## In-memory API
+
+Process images without any file I/O using `process_image`:
+
+```python
+from imgtools_m8 import process_image
+
+with open("photo.jpg", "rb") as f:
+    src_bytes = f.read()
+
+results = process_image(
+    src_bytes,
+    [{"image_size": {"fixed_width": 200}, "formats": [{"ext": "WEBP", "quality": 80}]}],
+)
+
+for r in results:
+    print(r.name, r.width, r.height, r.size_bytes)
+    # write r.data to a file or upload directly
+```
+
+`process_image` returns a `list[VariantResult]`; each result carries `name`, `data` (raw bytes),
+`width`, `height`, `size_bytes`, and `format`. No disk paths required.
+
 ## DNN upscaling note
 
 When `opencv-contrib-python` is not installed, `fixed_upscale` falls back to PIL bicubic scaling.
@@ -331,11 +354,12 @@ A `docker-compose.yml` for multi-volume GPU batch processing is in `docker_compo
 ## Input/Output Example
 
 ### Input Image
+
 The source file is 340×216 px.
-<div align="center">
-  <img src="https://raw.githubusercontent.com/mano8/imgtools_m8/main/tests/sources_test/recien_llegado.jpg" alt="Recien Llegado @Cezar llañez" width="340" height="216" />
-  <p>Recien llegado by <a href="https://www.ichingmaestrodelosespiritus.com/">@Cezar yañez</a></p>
-</div>
+
+![Recien Llegado @Cezar llañez](https://raw.githubusercontent.com/mano8/imgtools_m8/main/tests/sources_test/recien_llegado.jpg)
+
+*Recien llegado by [@Cezar yañez](https://www.ichingmaestrodelosespiritus.com/)*
 
 ## License
 

--- a/imgtools_m8/__init__.py
+++ b/imgtools_m8/__init__.py
@@ -75,3 +75,9 @@ def configure_logging(debug: bool = False) -> None:
     logger.addHandler(handler)
 
     logger.debug("Logger ready. debug=%s colorama=%s", debug, _COLORAMA_AVAILABLE)
+
+
+from imgtools_m8.image_process import process_image  # noqa: E402
+from imgtools_m8.results import VariantResult  # noqa: E402
+
+__all__ = ["process_image", "VariantResult", "configure_logging"]

--- a/imgtools_m8/image_process.py
+++ b/imgtools_m8/image_process.py
@@ -4,7 +4,7 @@ import io
 import logging
 import os
 from os.path import basename, isdir, isfile, join, splitext
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from PIL import Image, UnidentifiedImageError
 from pydantic import TypeAdapter
@@ -12,6 +12,7 @@ from pydantic import TypeAdapter
 from imgtools_m8.helpers.file_utils import FileUtils
 from imgtools_m8.helpers.model_conf import ModelConf
 from imgtools_m8.helpers.scan_dir import ScanDir
+from imgtools_m8.results import VariantResult
 from imgtools_m8.schemas.conf_schema import (
     FormatsList,
     ImageProcessingSchema,
@@ -288,6 +289,34 @@ class ImageProcessing:
         return img
 
     @staticmethod
+    def _encode_to_bytes(
+        img: Image.Image,
+        format_conf,
+        max_byte_size: Optional[int] = None,
+    ) -> bytes:
+        """Encode an image to in-memory bytes for a specific format.
+
+        Applies the same colour-mode conversion and ``max_byte_size`` quality
+        search used when writing to disk, so the encoded stream is identical to
+        what :meth:`_write_image_to_format` persists.
+        """
+        fmt_val = format_conf.ext.value
+        working = ImageProcessing._convert_color_mode(img, fmt_val)
+        if max_byte_size:
+            save_kwargs = ImageProcessing._enforce_max_bytes(
+                working, format_conf, max_byte_size
+            )
+        else:
+            save_kwargs = {
+                k: v
+                for k, v in format_conf.model_dump(exclude={"ext"}).items()
+                if v is not None
+            }
+        buf = io.BytesIO()
+        working.save(buf, format=fmt_val, **save_kwargs)
+        return buf.getvalue()
+
+    @staticmethod
     def _write_image_to_format(
         img: Image.Image,
         output_dir: str,
@@ -300,20 +329,10 @@ class ImageProcessing:
         ext = _EXT_MAP.get(fmt_val, f".{fmt_val.lower()}")
         out_path = join(output_dir, f"{stem}{ext}")
 
-        working = ImageProcessing._convert_color_mode(img, fmt_val)
-
         try:
-            if max_byte_size:
-                save_kwargs = ImageProcessing._enforce_max_bytes(
-                    working, format_conf, max_byte_size
-                )
-            else:
-                save_kwargs = {
-                    k: v
-                    for k, v in format_conf.model_dump(exclude={"ext"}).items()
-                    if v is not None
-                }
-            working.save(out_path, format=fmt_val, **save_kwargs)
+            data = ImageProcessing._encode_to_bytes(img, format_conf, max_byte_size)
+            with open(out_path, "wb") as handle:
+                handle.write(data)
             logger.debug(
                 "[ImageProcessing] Wrote %s (%s)",
                 out_path,
@@ -525,3 +544,74 @@ class ImageProcessing:
     ) -> bool:
         """Check if output_format is a valid format config instance."""
         return isinstance(output_format, FormatsList)
+
+
+def process_image(
+    source: bytes,
+    output_options: List[dict],
+    model_conf: Optional[dict] = None,
+) -> List[VariantResult]:
+    """Encode in-memory image bytes into resized/converted variants.
+
+    Storage-agnostic counterpart to :meth:`ImageProcessing.run`: it never
+    touches the filesystem. ``output_options`` is validated against the shipped
+    :class:`OutputOptions` schema (nested ``image_size`` + ``OutputFormatsEnum``)
+    and the shared resize/encode pipeline helpers are reused unchanged.
+
+    Args:
+        source: Raw encoded image bytes (any Pillow-readable format).
+        output_options: Output-option dicts (same shape as the file pipeline).
+            Each may carry an optional ``name`` label (≤64 chars).
+        model_conf: Optional DNN upscaling model configuration. When a
+            ``fixed_upscale`` option requests DNN upscaling but the model file is
+            absent, the PR#1 resolver raises ``ModelNotFoundError`` (no fallback).
+
+    Returns:
+        One :class:`VariantResult` per produced format; empty options yield ``[]``.
+
+    Raises:
+        ValueError: If ``source`` is not a decodable image.
+    """
+    options = TypeAdapter(List[OutputOptions]).validate_python(output_options)
+    if not options:
+        return []
+
+    try:
+        image = Image.open(io.BytesIO(source))
+        image.load()
+    except UnidentifiedImageError as exc:
+        raise ValueError("source is not a valid image") from exc
+
+    # Reuse the shipped pipeline via a minimal, storage-agnostic instance: it
+    # wires the optional DNN expander (model_conf) and exposes _apply_resize.
+    # flatten_output satisfies the schema without file-bound output_options.
+    processor = ImageProcessing(
+        conf={
+            "source_path": "<bytes>",
+            "output_path": "<bytes>",
+            "flatten_output": True,
+        },
+        model_conf=model_conf,
+    )
+
+    results: List[VariantResult] = []
+    for raw, option in zip(output_options, options):
+        working = processor._apply_resize(image, option)
+        label = raw.get("name") or ImageProcessing._get_output_stem(
+            "image", working.size
+        )
+        for fmt_conf in option.formats or []:
+            data = ImageProcessing._encode_to_bytes(
+                working, fmt_conf, option.max_byte_size
+            )
+            results.append(
+                VariantResult(
+                    name=label,
+                    data=data,
+                    width=working.width,
+                    height=working.height,
+                    size_bytes=len(data),
+                    format=fmt_conf.ext.value,
+                )
+            )
+    return results

--- a/imgtools_m8/results.py
+++ b/imgtools_m8/results.py
@@ -1,0 +1,36 @@
+"""Storage-agnostic result types for the in-memory image API.
+
+These types intentionally carry no database, filesystem, or service fields so
+they can be reused unchanged by any consumer (SD5).
+"""
+
+from dataclasses import dataclass
+
+__author__ = "Eli Serra"
+__copyright__ = "Copyright 2020, Eli Serra"
+__deprecated__ = False
+__license__ = "Apache Software License"
+__status__ = "Production"
+__version__ = "1.0.0"
+
+
+@dataclass(frozen=True)
+class VariantResult:
+    """A single encoded image variant produced by ``process_image``.
+
+    Attributes:
+        name: A caller-supplied label (≤64 chars) or a derived ``stem_WxH``
+            label. Purely informational — not a path or storage key.
+        data: The encoded image bytes.
+        width: Variant width in pixels.
+        height: Variant height in pixels.
+        size_bytes: Length of ``data`` in bytes.
+        format: Output format name (e.g. ``"JPEG"``, ``"WEBP"``).
+    """
+
+    name: str
+    data: bytes
+    width: int
+    height: int
+    size_bytes: int
+    format: str

--- a/tests/test_image_process.py
+++ b/tests/test_image_process.py
@@ -392,6 +392,32 @@ class TestWriteImageToFormat:
         )
         assert result is False
 
+    def test_written_file_is_byte_identical_to_direct_encode(self, output_path):
+        # O5: _write_image_to_format now writes _encode_to_bytes' buffer to disk.
+        # The persisted file must be byte-identical to a direct PIL encode with the
+        # same colour conversion + save kwargs (the pre-extraction behavior).
+        from io import BytesIO
+
+        src = join(HelperTest.get_source_path(), "cat1", "mar.jpg")
+        with Image.open(src) as img:
+            img.load()
+            fmt = JpegFormat(quality=70, optimize=True)
+            assert ImageProcessing._write_image_to_format(
+                img, output_path, "byte_identical", fmt
+            )
+            # Replicate the original direct-save logic independently.
+            working = ImageProcessing._convert_color_mode(img, "JPEG")
+            kwargs = {
+                k: v
+                for k, v in fmt.model_dump(exclude={"ext"}).items()
+                if v is not None
+            }
+            buf = BytesIO()
+            working.save(buf, format="JPEG", **kwargs)
+        with open(join(output_path, "byte_identical.jpg"), "rb") as fh:
+            on_disk = fh.read()
+        assert on_disk == buf.getvalue()
+
 
 # ---------------------------------------------------------------------------
 # _dnn_upscale fallback (no DNN available)

--- a/tests/test_process_image_bytes.py
+++ b/tests/test_process_image_bytes.py
@@ -1,0 +1,177 @@
+"""Tests for the in-memory ``process_image`` bytes API.
+
+Use pytest package.
+"""
+
+import io
+from os.path import join
+
+import pytest
+from PIL import Image
+
+from imgtools_m8.image_process import process_image
+from imgtools_m8.results import VariantResult
+
+from .helper import HelperTest
+
+__author__ = "Eli Serra"
+__copyright__ = "Copyright 2020, Eli Serra"
+__deprecated__ = False
+__license__ = "Apache Software License"
+__status__ = "Production"
+__version__ = "1.0.0"
+
+
+# mar.jpg is a real portrait fixture (276x397) — never hardcode pixels blindly.
+MAR_PATH = join(HelperTest.get_source_path(), "mar.jpg")
+
+
+def _mar_bytes() -> bytes:
+    """Return the raw bytes of the portrait mar.jpg fixture."""
+    with open(MAR_PATH, "rb") as fh:
+        return fh.read()
+
+
+def _rgba_png_bytes() -> bytes:
+    """Return PNG bytes of an RGBA image (has an alpha channel)."""
+    img = Image.new("RGBA", (60, 40), (255, 0, 0, 128))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Aspect ratio (no hardcoded pixels — derive from the real fixture)
+# ---------------------------------------------------------------------------
+
+
+class TestAspectRatio:
+    def test_fixed_width_preserves_aspect_ratio(self):
+        with Image.open(MAR_PATH) as src:
+            orig_w, orig_h = src.size
+        results = process_image(
+            _mar_bytes(),
+            [{"image_size": {"fixed_width": 200}, "formats": [{"ext": "WEBP"}]}],
+        )
+        assert len(results) == 1
+        variant = results[0]
+        assert variant.width == 200
+        assert variant.height == round(orig_h * (200 / orig_w))
+        assert variant.format == "WEBP"
+        assert isinstance(variant, VariantResult)
+        assert isinstance(variant.data, bytes)
+        assert variant.size_bytes == len(variant.data)
+
+
+# ---------------------------------------------------------------------------
+# Decode / validation edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestDecodeAndOptions:
+    def test_invalid_bytes_raise_value_error(self):
+        with pytest.raises(ValueError):
+            process_image(
+                b"definitely not an image",
+                [{"image_size": {"fixed_width": 50}, "formats": [{"ext": "JPEG"}]}],
+            )
+
+    def test_empty_options_return_empty_list(self):
+        assert process_image(_mar_bytes(), []) == []
+
+
+# ---------------------------------------------------------------------------
+# Colour-mode conversion (RGBA source -> JPEG)
+# ---------------------------------------------------------------------------
+
+
+class TestColorModeConversion:
+    def test_rgba_source_encoded_as_jpeg(self):
+        results = process_image(
+            _rgba_png_bytes(),
+            [{"formats": [{"ext": "JPEG", "quality": 80}]}],
+        )
+        assert len(results) == 1
+        variant = results[0]
+        assert variant.format == "JPEG"
+        # JPEG cannot hold alpha — decoded variant must be alpha-free.
+        with Image.open(io.BytesIO(variant.data)) as decoded:
+            assert decoded.format == "JPEG"
+            assert decoded.mode in ("RGB", "L")
+
+
+# ---------------------------------------------------------------------------
+# max_byte_size is honoured
+# ---------------------------------------------------------------------------
+
+
+class TestMaxByteSize:
+    def test_max_byte_size_constrains_output(self):
+        max_bytes = 3_000
+        results = process_image(
+            _mar_bytes(),
+            [
+                {
+                    "image_size": {"fixed_width": 200},
+                    "max_byte_size": max_bytes,
+                    "formats": [{"ext": "JPEG", "quality": 90}],
+                }
+            ],
+        )
+        assert len(results) == 1
+        assert results[0].size_bytes <= max_bytes
+
+
+# ---------------------------------------------------------------------------
+# name label: caller-supplied vs derived stem
+# ---------------------------------------------------------------------------
+
+
+class TestNameLabel:
+    def test_name_supplied_is_used(self):
+        results = process_image(
+            _mar_bytes(),
+            [
+                {
+                    "name": "thumbnail",
+                    "image_size": {"fixed_width": 200},
+                    "formats": [{"ext": "WEBP"}],
+                }
+            ],
+        )
+        assert results[0].name == "thumbnail"
+
+    def test_name_unset_derives_stem(self):
+        results = process_image(
+            _mar_bytes(),
+            [{"image_size": {"fixed_width": 200}, "formats": [{"ext": "WEBP"}]}],
+        )
+        variant = results[0]
+        assert variant.name == f"image_{variant.width}x{variant.height}"
+
+
+# ---------------------------------------------------------------------------
+# Multi-format option yields multiple results
+# ---------------------------------------------------------------------------
+
+
+class TestMultiFormat:
+    def test_multiple_formats_yield_multiple_results(self):
+        results = process_image(
+            _mar_bytes(),
+            [
+                {
+                    "image_size": {"fixed_width": 120},
+                    "formats": [
+                        {"ext": "JPEG", "quality": 75},
+                        {"ext": "WEBP", "quality": 75},
+                        {"ext": "PNG"},
+                    ],
+                }
+            ],
+        )
+        assert len(results) == 3
+        assert {r.format for r in results} == {"JPEG", "WEBP", "PNG"}
+        # All variants share the resized dimensions and derived label.
+        assert {(r.width, r.height) for r in results} == {(120, round(397 * 120 / 276))}
+        assert len({r.name for r in results}) == 1


### PR DESCRIPTION
## Summary
Adds a storage-agnostic, in-memory image API: `process_image(bytes) -> list[VariantResult]`,
reusing the existing Pillow pipeline helpers. No file I/O required.

## Changes
- `VariantResult(name, data, width, height, size_bytes, format)` — neutral result type, no
  storage/DB fields.
- `process_image(source: bytes, output_options: list[dict], model_conf=None)` — validates against
  the existing `OutputOptions` schema, decodes once, reuses the resize helpers and the new
  `_encode_to_bytes` (extracted from the file writer; on-disk output unchanged).
- Upscale-without-models raises `ModelNotFoundError` (consistent with PR#1).
- Exported from `imgtools_m8` (`process_image`, `VariantResult`).

## Testing
Full gate green; new `tests/test_process_image_bytes.py` covers resize (aspect-ratio asserted),
invalid bytes → `ValueError`, empty options → `[]`, RGBA→JPEG, `max_byte_size`, multi-format.