### PR TITLE
chore(release): 2.0.0 prep — ConfigDict migration + RELEASE_TAG coupling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - 2026-06-05
 
 ### Added
 

--- a/imgtools_m8/helpers/model_downloader.py
+++ b/imgtools_m8/helpers/model_downloader.py
@@ -11,6 +11,7 @@ import os
 from urllib.error import URLError
 from urllib.request import urlopen
 
+from imgtools_m8 import __version__
 from imgtools_m8.helper import ImageToolsHelper
 
 __author__ = "Eli Serra"
@@ -18,12 +19,15 @@ __copyright__ = "Copyright 2020, Eli Serra"
 __deprecated__ = False
 __license__ = "Apache Software License"
 __status__ = "Production"
-__version__ = "2.0.0"
 
-RELEASE_TAG = "v2.0.0"
+# The release tag tracks the package version so the downloader, the git release
+# tag, and the publish workflow's asset upload (`gh release upload <tag>`) always
+# line up. Tag every release `v{__version__}` and the model URLs resolve for free.
+RELEASE_TAG = f"v{__version__}"
 BASE_URL = f"https://github.com/mano8/imgtools_m8/releases/download/{RELEASE_TAG}"
 
-# Real SHA256 digests are filled in Phase C2 (Sonnet); placeholders for now.
+# SHA256 digests must match the assets/models/opencv/*.pb files uploaded to the
+# release; the downloader verifies every fetch against these.
 MODEL_REGISTRY: dict[str, dict[str, list[dict[str, str]]]] = {
     "opencv": {
         "edsr": [

--- a/imgtools_m8/schemas/upscaler_schema.py
+++ b/imgtools_m8/schemas/upscaler_schema.py
@@ -2,7 +2,7 @@
 
 from typing import Literal, Optional, cast
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import TypedDict
 
 from imgtools_m8.helpers.regex_patterns import ValidationConstants
@@ -31,11 +31,7 @@ class UpscaleModelType(BaseModel):
     )
     scale: Optional[int] = Field(None, ge=1, le=8, description="Upscaler scale factor.")
 
-    class Config:
-        """Pydantic Config"""
-
-        extra = "forbid"
-        frozen = True
+    model_config = ConfigDict(extra="forbid", frozen=True)
 
     def to_dict(self) -> UpscaleModelDict:
         """Convert to dictionary."""


### PR DESCRIPTION
## Summary

Final pre-publish polish for the 2.0.0 release (EDSR/OpenCV upscaler + externalized models + in-memory bytes API). No behavior change to the public API — quality and release-hygiene only.

## Changes

- **`fix(schemas)`** — migrate `UpscaleModelType` from the Pydantic V1 inner `class Config` to `model_config = ConfigDict(extra="forbid", frozen=True)`. Removes the `PydanticDeprecatedSince20` warning emitted on every model validation and prevents a hard break under Pydantic V3 (allowed by the `pydantic>=2.13.4` floor).
- **`chore(release)`** — derive `RELEASE_TAG` from `imgtools_m8.__version__` (`f"v{__version__}"`) so the downloader URLs, the git release tag, and the publish workflow's `gh release upload <tag>` step stay in lockstep every release instead of a hand-synced literal. Drops the duplicate module-level `__version__` and the stale Phase-C2 placeholder comment (digests are real and verified).
- **`docs`** — promote CHANGELOG `[Unreleased]` → `[2.0.0] - 2026-06-05`.

## Verification

- `ruff format --check` / `ruff check` / `mypy` — clean
- `pytest --cov --cov-fail-under=100` — **359 passed, 100% coverage, 0 warnings**
- `bandit -r imgtools_m8 --severity-level medium` — clean
- `python -m build` + `twine check` — both PASSED (wheel ships only `imgtools_m8/`, no model binaries)
- Model SHA256 digests verified to match `assets/models/opencv/*.pb`
- `RELEASE_TAG` resolves to `v2.0.0`, no circular import

## Post-merge release steps

1. Tag the GitHub release exactly **`v2.0.0`** (now enforced-by-construction via the `RELEASE_TAG` coupling).
2. Confirm the `PYPI_API_TOKEN` repo secret exists — the publish workflow attaches the `.pb` assets to that tag's release, then publishes to PyPI.