### PR TITLE
Release 2.1.0: async in-memory bytes API

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,67 @@ for r in results:
 `process_image` returns a `list[VariantResult]`; each result carries `name`, `data` (raw bytes),
 `width`, `height`, `size_bytes`, and `format`. No disk paths required.
 
+## Async / FastAPI usage
+
+`process_image` is synchronous and CPU-bound (Pillow/OpenCV decode, resize, encode).
+Calling it directly from an `async def` route blocks the event loop for the whole encode,
+starving every other in-flight request. The async wrappers offload that work to a worker
+thread so the loop stays responsive:
+
+```python
+from imgtools_m8 import process_image_async, process_images_async
+
+@app.post("/resize")
+async def resize(file: UploadFile):
+    src_bytes = await file.read()
+    results = await process_image_async(
+        src_bytes,
+        [{"image_size": {"fixed_width": 200}, "formats": [{"ext": "WEBP", "quality": 80}]}],
+    )
+    return {"variants": [r.name for r in results]}
+
+@app.post("/resize-batch")
+async def resize_batch(files: list[UploadFile]):
+    sources = [await f.read() for f in files]
+    # one list[VariantResult] per source, order preserved
+    batches = await process_images_async(
+        sources,
+        [{"image_size": {"fixed_width": 64}, "formats": [{"ext": "JPEG"}]}],
+    )
+    return {"count": len(batches)}
+```
+
+A few things worth knowing:
+
+- **What async buys you:** the image work is still CPU-bound. `await process_image_async(...)`
+  does **not** make encoding asynchronous — it runs the existing synchronous pipeline in a
+  worker thread so it no longer blocks the event loop. The execution *location* changed, not
+  the work. Because Pillow/OpenCV release the GIL during encode/decode/resize, this also gives
+  real parallelism for concurrent requests.
+- **Thread-pool behavior:** the work runs on the event loop's default thread pool, which has a
+  bounded worker count managed by the loop. `process_images_async([...])` schedules every source
+  via `asyncio.gather`, but the executor caps how many run at once — passing thousands of sources
+  creates thousands of awaitables, not thousands of OS threads.
+- **Cancellation:** cancelling the awaiting task does not stop image processing already running
+  in a worker thread (standard `asyncio.to_thread` behavior).
+- **Heterogeneous options:** `process_images_async` applies the same `output_options` to every
+  source. For per-image differing options, compose `asyncio.gather` over `process_image_async`
+  directly:
+
+  ```python
+  import asyncio
+
+  batches = await asyncio.gather(
+      process_image_async(img1, opts1),
+      process_image_async(img2, opts2),
+  )
+  ```
+
+- **Security boundary:** these wrappers do not alter image validation, decoding,
+  decompression-bomb protections, or upload-size controls. Input validation and request limits
+  remain the caller's responsibility — see Pillow's `Image.MAX_IMAGE_PIXELS` and your framework's
+  upload-size caps.
+
 ## DNN upscaling note
 
 When `opencv-contrib-python` is not installed, `fixed_upscale` falls back to PIL bicubic scaling.

--- a/imgtools_m8/__init__.py
+++ b/imgtools_m8/__init__.py
@@ -7,7 +7,7 @@ __copyright__ = "Copyright 2023, Eli Serra"
 __deprecated__ = False
 __license__ = "Apache Software License"
 __status__ = "Production"
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 try:
     import colorama
@@ -77,7 +77,17 @@ def configure_logging(debug: bool = False) -> None:
     logger.debug("Logger ready. debug=%s colorama=%s", debug, _COLORAMA_AVAILABLE)
 
 
+from imgtools_m8.async_api import (  # noqa: E402
+    process_image_async,
+    process_images_async,
+)
 from imgtools_m8.image_process import process_image  # noqa: E402
 from imgtools_m8.results import VariantResult  # noqa: E402
 
-__all__ = ["process_image", "VariantResult", "configure_logging"]
+__all__ = [
+    "process_image",
+    "process_image_async",
+    "process_images_async",
+    "VariantResult",
+    "configure_logging",
+]

--- a/imgtools_m8/async_api.py
+++ b/imgtools_m8/async_api.py
@@ -37,9 +37,7 @@ async def process_image_async(
     processing remains CPU-bound — only its execution location changes.
     Same args, return value, and exceptions as :func:`process_image`.
     """
-    return await asyncio.to_thread(
-        process_image, source, output_options, model_conf
-    )
+    return await asyncio.to_thread(process_image, source, output_options, model_conf)
 
 
 async def process_images_async(

--- a/imgtools_m8/async_api.py
+++ b/imgtools_m8/async_api.py
@@ -1,0 +1,63 @@
+"""Async, non-blocking wrappers over the in-memory Bytes API.
+
+These offload the CPU-bound :func:`process_image` pipeline to a worker
+thread so it never blocks an asyncio event loop (e.g. FastAPI routes).
+Pillow/OpenCV release the GIL during encode/decode/resize, so threads
+keep the loop responsive and allow real concurrency.
+
+The work itself stays CPU-bound: these helpers change *where* it runs,
+not its nature. They run on the event loop's default thread pool
+(``asyncio.to_thread``), which has a bounded worker count managed by the
+loop. ``process_images_async`` schedules all sources at once via ``gather``,
+but the executor runs them at that bounded concurrency.
+
+Cancelling the awaiting task (``task.cancel()``) abandons the *await*; the
+underlying thread keeps running until ``process_image`` returns — standard
+``asyncio.to_thread`` behavior.
+"""
+
+import asyncio
+from typing import List, Optional, Sequence
+
+from imgtools_m8.image_process import process_image
+from imgtools_m8.results import VariantResult
+
+__all__ = ["process_image_async", "process_images_async"]
+
+
+async def process_image_async(
+    source: bytes,
+    output_options: List[dict],
+    model_conf: Optional[dict] = None,
+) -> List[VariantResult]:
+    """Async, non-blocking counterpart of :func:`process_image`.
+
+    Runs the synchronous pipeline in the loop's default ``ThreadPoolExecutor``
+    via ``asyncio.to_thread`` so the calling event loop stays free. The
+    processing remains CPU-bound — only its execution location changes.
+    Same args, return value, and exceptions as :func:`process_image`.
+    """
+    return await asyncio.to_thread(
+        process_image, source, output_options, model_conf
+    )
+
+
+async def process_images_async(
+    sources: Sequence[bytes],
+    output_options: List[dict],
+    model_conf: Optional[dict] = None,
+) -> List[List[VariantResult]]:
+    """Process multiple source images concurrently.
+
+    Applies the same ``output_options``/``model_conf`` to each source and
+    fans the work out across worker threads with ``asyncio.gather``.
+    Results preserve input order: one ``List[VariantResult]`` per source.
+    All sources are scheduled together; if any fails, the first exception
+    encountered by ``asyncio.gather`` is propagated to the caller (other
+    threads may already be running and are not actively stopped).
+    """
+    if not sources:
+        return []
+    return await asyncio.gather(
+        *(process_image_async(src, output_options, model_conf) for src in sources)
+    )

--- a/tests/test_async_process_image.py
+++ b/tests/test_async_process_image.py
@@ -1,0 +1,121 @@
+"""Tests for the async in-memory bytes API wrappers.
+
+The coroutines are driven from ordinary sync tests via ``asyncio.run`` so the
+suite needs no extra test dependency (no ``pytest-asyncio``). Each case proves
+the wrapper strictly delegates to the synchronous ``process_image`` — same
+results, same exceptions.
+"""
+
+import asyncio
+from os.path import join
+
+import pytest
+
+from imgtools_m8.async_api import process_image_async, process_images_async
+from imgtools_m8.image_process import process_image
+from imgtools_m8.results import VariantResult
+
+from .helper import HelperTest
+
+__author__ = "Eli Serra"
+__copyright__ = "Copyright 2020, Eli Serra"
+__deprecated__ = False
+__license__ = "Apache Software License"
+__status__ = "Production"
+__version__ = "1.0.0"
+
+
+MAR_PATH = join(HelperTest.get_source_path(), "mar.jpg")
+
+
+def _mar_bytes() -> bytes:
+    """Return the raw bytes of the portrait mar.jpg fixture."""
+    with open(MAR_PATH, "rb") as fh:
+        return fh.read()
+
+
+_WEBP_OPTS = [{"image_size": {"fixed_width": 200}, "formats": [{"ext": "WEBP"}]}]
+
+
+def _assert_variants_equal(
+    async_results: list[VariantResult], sync_results: list[VariantResult]
+) -> None:
+    """Assert two variant lists are byte-for-byte identical."""
+    assert len(async_results) == len(sync_results)
+    for a, s in zip(async_results, sync_results):
+        assert a.data == s.data  # full byte-equality: strongest delegation proof
+        assert a.name == s.name
+        assert a.width == s.width
+        assert a.height == s.height
+        assert a.size_bytes == s.size_bytes
+        assert a.format == s.format
+
+
+# ---------------------------------------------------------------------------
+# process_image_async — single image
+# ---------------------------------------------------------------------------
+
+
+class TestProcessImageAsync:
+    def test_parity_with_sync(self):
+        src = _mar_bytes()
+        async_results = asyncio.run(process_image_async(src, _WEBP_OPTS))
+        sync_results = process_image(src, _WEBP_OPTS)
+        _assert_variants_equal(async_results, sync_results)
+        assert isinstance(async_results[0], VariantResult)
+
+    def test_invalid_bytes_raise_value_error(self):
+        with pytest.raises(ValueError):
+            asyncio.run(
+                process_image_async(
+                    b"definitely not an image",
+                    [{"image_size": {"fixed_width": 50}, "formats": [{"ext": "JPEG"}]}],
+                )
+            )
+
+    def test_exception_parity_same_message(self):
+        bad = b"definitely not an image"
+        opts = [{"image_size": {"fixed_width": 50}, "formats": [{"ext": "JPEG"}]}]
+        with pytest.raises(ValueError) as sync_exc:
+            process_image(bad, opts)
+        with pytest.raises(ValueError) as async_exc:
+            asyncio.run(process_image_async(bad, opts))
+        assert str(sync_exc.value) == str(async_exc.value)
+
+    def test_empty_options_return_empty_list(self):
+        assert asyncio.run(process_image_async(_mar_bytes(), [])) == []
+
+    def test_model_conf_passthrough(self):
+        # Non-DNN option path: model_conf is forwarded but unused, matching how
+        # the sync tests avoid requiring the model file on disk.
+        src = _mar_bytes()
+        model_conf = {"path": "/nonexistent", "model_name": "edsr", "scale": 4}
+        async_results = asyncio.run(
+            process_image_async(src, _WEBP_OPTS, model_conf)
+        )
+        sync_results = process_image(src, _WEBP_OPTS, model_conf)
+        _assert_variants_equal(async_results, sync_results)
+
+
+# ---------------------------------------------------------------------------
+# process_images_async — concurrent batch
+# ---------------------------------------------------------------------------
+
+
+class TestProcessImagesAsync:
+    def test_batch_order_and_shape(self):
+        src = _mar_bytes()
+        sources = [src, src, src]
+        batches = asyncio.run(process_images_async(sources, _WEBP_OPTS))
+        assert len(batches) == 3
+        expected = process_image(src, _WEBP_OPTS)
+        for inner in batches:
+            _assert_variants_equal(inner, expected)
+
+    def test_empty_batch_returns_empty_list(self):
+        assert asyncio.run(process_images_async([], _WEBP_OPTS)) == []
+
+    def test_batch_error_propagates(self):
+        sources = [_mar_bytes(), b"not an image"]
+        with pytest.raises(ValueError):
+            asyncio.run(process_images_async(sources, _WEBP_OPTS))

--- a/tests/test_async_process_image.py
+++ b/tests/test_async_process_image.py
@@ -90,9 +90,7 @@ class TestProcessImageAsync:
         # the sync tests avoid requiring the model file on disk.
         src = _mar_bytes()
         model_conf = {"path": "/nonexistent", "model_name": "edsr", "scale": 4}
-        async_results = asyncio.run(
-            process_image_async(src, _WEBP_OPTS, model_conf)
-        )
+        async_results = asyncio.run(process_image_async(src, _WEBP_OPTS, model_conf))
         sync_results = process_image(src, _WEBP_OPTS, model_conf)
         _assert_variants_equal(async_results, sync_results)
 


### PR DESCRIPTION
Adds a thin, non-blocking sibling to the synchronous `process_image` bytes API so it can be called safely from async web frameworks (e.g. FastAPI). Tagged for PyPI publish as **2.1.0** (current latest on PyPI: 2.0.0).

### What changed
- **New module `imgtools_m8/async_api.py`** with two coroutines:
  - `process_image_async(source, output_options, model_conf=None)` — offloads the CPU-bound `process_image` pipeline to a worker thread via `asyncio.to_thread`, keeping the event loop free.
  - `process_images_async(sources, output_options, model_conf=None)` — applies the same options to multiple sources concurrently via `asyncio.gather`; returns one `list[VariantResult]` per source, order preserved.
- **Exports** both helpers from `imgtools_m8/__init__.py`.
- **Version bump** `2.0.0` → `2.1.0` (backward-compatible feature addition; `pyproject.toml` reads it dynamically).
- **README**: new "Async / FastAPI usage" section covering what async buys you (work stays CPU-bound, only its location changes), thread-pool bounds, cancellation semantics, heterogeneous-options pattern, and the unchanged security boundary.
- **Tests** `tests/test_async_process_image.py`: byte-level parity with the sync API, exception parity (same `ValueError` message), empty options/batch, `model_conf` passthrough, batch order/shape, and batch error propagation. Coroutines driven via `asyncio.run` — no new test dependency.

### Design notes
- No FastAPI / anyio / new runtime dependency — stays a pure compute library (stdlib `asyncio` only). Pillow/OpenCV release the GIL during encode/decode/resize, so a thread genuinely frees the loop and gives real concurrency.
- Strict delegation: no pipeline logic reimplemented; sync `process_image` behavior and signature unchanged.
- Thread-safe by construction — each call builds a fresh `ImageProcessing`/expander and its own `Image.open`; no shared mutable state.

### Verification
- `pytest -q` — 367 passed
- `pytest --cov=imgtools_m8 --cov-report=term-missing` — 100% overall, `async_api.py` at 100%
- `ruff check imgtools_m8 tests` — clean
- `mypy imgtools_m8` — no issues